### PR TITLE
Link to clang at runtime

### DIFF
--- a/metis-sys/Cargo.toml
+++ b/metis-sys/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["graph", "mesh", "matrix", "partitioning", "ordering"]
 
 
 [build-dependencies]
-bindgen = { version = "0.65", default-features = false }
+bindgen = { version = "0.65", default-features = false, features = ["runtime"] }

--- a/metis-sys/Cargo.toml
+++ b/metis-sys/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["graph", "mesh", "matrix", "partitioning", "ordering"]
 
 
 [build-dependencies]
-bindgen = { version = "0.65", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.66", default-features = false, features = ["runtime"] }

--- a/metis-sys/Cargo.toml
+++ b/metis-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metis-sys"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Hubert Hirtz <hubert@hirtz.pm>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
this makes bindgen load libclang during the execution of build instead
of its compilation.

it also has the advantage that older versions of clang are supported.
see the following links for statements:
- https://github.com/rust-lang/rust-bindgen/issues/1694
- https://github.com/Janekdererste/metis-rs#why-this-fork