### PR TITLE
Constify API

### DIFF
--- a/metis-sys/wrapper.h
+++ b/metis-sys/wrapper.h
@@ -1,1 +1,61 @@
+/* Include metis, but add const modifiers to pointer arguments where relevant,
+ * so that the generated Rust bindings can use shared references.
+ * As far as I can tell, METIS does not modify these, or otherwise does not
+ * require exclusive access to the data behind those pointers.
+ */
+
+#define METIS_MeshToDual rs_METIS_MeshToDual
+#define METIS_PartGraphKway rs_METIS_PartGraphKway
+#define METIS_PartGraphRecursive rs_METIS_PartGraphRecursive
+#define METIS_PartMeshDual rs_METIS_PartMeshDual
+#define METIS_PartMeshNodal rs_METIS_PartMeshNodal
+
 #include <metis.h>
+
+#undef METIS_MeshToDual
+#undef METIS_PartGraphKway
+#undef METIS_PartGraphRecursive
+#undef METIS_PartMeshDual
+#undef METIS_PartMeshNodal
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+METIS_API(int)
+METIS_MeshToDual(const idx_t *ne, const idx_t *nn, const idx_t *eptr,
+                 const idx_t *eind, const idx_t *ncommon, const idx_t *numflag,
+                 idx_t **r_xadj, idx_t **r_adjncy);
+
+METIS_API(int)
+METIS_PartGraphKway(const idx_t *nvtxs, const idx_t *ncon, const idx_t *xadj,
+                    const idx_t *adjncy, const idx_t *vwgt, const idx_t *vsize,
+                    const idx_t *adjwgt, const idx_t *nparts,
+                    const real_t *tpwgts, const real_t *ubvec,
+                    const idx_t *options, idx_t *edgecut, idx_t *part);
+
+METIS_API(int)
+METIS_PartGraphRecursive(const idx_t *nvtxs, const idx_t *ncon,
+                         const idx_t *xadj, const idx_t *adjncy,
+                         const idx_t *vwgt, const idx_t *vsize,
+                         const idx_t *adjwgt, const idx_t *nparts,
+                         const real_t *tpwgts, const real_t *ubvec,
+                         const idx_t *options, idx_t *edgecut, idx_t *part);
+
+METIS_API(int)
+METIS_PartMeshDual(const idx_t *ne, const idx_t *nn, const idx_t *eptr,
+                   const idx_t *eind, const idx_t *vwgt, const idx_t *vsize,
+                   const idx_t *ncommon, const idx_t *nparts,
+                   const real_t *tpwgts, const idx_t *options, idx_t *objval,
+                   idx_t *epart, idx_t *npart);
+
+METIS_API(int)
+METIS_PartMeshNodal(const idx_t *ne, const idx_t *nn, const idx_t *eptr,
+                    const idx_t *eind, const idx_t *vwgt, const idx_t *vsize,
+                    const idx_t *nparts, const real_t *tpwgts,
+                    const idx_t *options, idx_t *objval, idx_t *epart,
+                    idx_t *npart);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,8 @@ impl ErrorCode for m::rstatus_et {
 /// ```rust
 /// # use metis::Graph;
 /// // Make a graph with two vertices and an edge between the two.
-/// let xadj = &mut [0, 1, 2];
-/// let adjncy = &mut [1, 0];
+/// let xadj = &[0, 1, 2];
+/// let adjncy = &[1, 0];
 ///
 /// // Allocate the partition array which stores the partition of each vertex.
 /// let mut part = [0, 0];
@@ -110,39 +110,39 @@ pub struct Graph<'a> {
     nparts: Idx,
 
     /// The adjency structure of the graph (part 1).
-    xadj: &'a mut [Idx],
+    xadj: &'a [Idx],
 
     /// The adjency structure of the graph (part 2).
     ///
     /// Required size: xadj.last()
-    adjncy: &'a mut [Idx],
+    adjncy: &'a [Idx],
 
     /// The computational weights of the vertices.
     ///
     /// Required size: ncon * (xadj.len()-1)
-    vwgt: Option<&'a mut [Idx]>,
+    vwgt: Option<&'a [Idx]>,
 
     /// The communication weights of the vertices.
     ///
     /// Required size: xadj.len()-1
-    vsize: Option<&'a mut [Idx]>,
+    vsize: Option<&'a [Idx]>,
 
     /// The weight of the edges.
     ///
     /// Required size: xadj.last()
-    adjwgt: Option<&'a mut [Idx]>,
+    adjwgt: Option<&'a [Idx]>,
 
     /// The target partition weights of the vertices.
     ///
     /// If `None` then the graph is equally divided among the partitions.
     ///
     /// Required size: ncon * nparts
-    tpwgts: Option<&'a mut [Real]>,
+    tpwgts: Option<&'a [Real]>,
 
     /// Imbalance tolerances for each constraint.
     ///
     /// Required size: ncon
-    ubvec: Option<&'a mut [Real]>,
+    ubvec: Option<&'a [Real]>,
 
     /// Fine-tuning parameters.
     options: [Idx; NOPTIONS],
@@ -159,13 +159,7 @@ impl<'a> Graph<'a> {
     /// - `nparts` is not strictly greater than zero, or
     /// - `xadj` is empty, or
     /// - the length of `adjncy` is different than the last element of `xadj`.
-    ///
-    /// # Mutability
-    ///
-    /// While nothing should be modified by the [`Graph`] structure, METIS
-    /// doesn't specify any `const` modifier, so everything must be mutable on
-    /// Rust's side.
-    pub fn new(ncon: Idx, nparts: Idx, xadj: &'a mut [Idx], adjncy: &'a mut [Idx]) -> Graph<'a> {
+    pub fn new(ncon: Idx, nparts: Idx, xadj: &'a [Idx], adjncy: &'a [Idx]) -> Graph<'a> {
         assert!(0 < ncon, "ncon must be strictly greater than zero");
         assert!(0 < nparts, "nparts must be strictly greater than zero");
         let _ = Idx::try_from(xadj.len()).expect("xadj array larger than Idx::MAX");
@@ -195,7 +189,7 @@ impl<'a> Graph<'a> {
     ///
     /// This function panics if the length of `vwgt` is not `ncon` times the
     /// number of vertices.
-    pub fn set_vwgt(mut self, vwgt: &'a mut [Idx]) -> Graph<'a> {
+    pub fn set_vwgt(mut self, vwgt: &'a [Idx]) -> Graph<'a> {
         let vwgt_len = Idx::try_from(vwgt.len()).expect("vwgt array too large");
         assert_eq!(vwgt_len, self.ncon * (self.xadj.len() as Idx - 1));
         self.vwgt = Some(vwgt);
@@ -210,7 +204,7 @@ impl<'a> Graph<'a> {
     ///
     /// This function panics if the length of `vsize` is not the number of
     /// vertices.
-    pub fn set_vsize(mut self, vsize: &'a mut [Idx]) -> Graph<'a> {
+    pub fn set_vsize(mut self, vsize: &'a [Idx]) -> Graph<'a> {
         let vsize_len = Idx::try_from(vsize.len()).expect("vsize array too large");
         assert_eq!(vsize_len, self.xadj.len() as Idx - 1);
         self.vsize = Some(vsize);
@@ -225,7 +219,7 @@ impl<'a> Graph<'a> {
     ///
     /// This function panics if the length of `adjwgt` is not equal to the
     /// length of `adjncy`.
-    pub fn set_adjwgt(mut self, adjwgt: &'a mut [Idx]) -> Graph<'a> {
+    pub fn set_adjwgt(mut self, adjwgt: &'a [Idx]) -> Graph<'a> {
         let adjwgt_len = Idx::try_from(adjwgt.len()).expect("adjwgt array too large");
         assert_eq!(adjwgt_len, *self.xadj.last().unwrap());
         self.adjwgt = Some(adjwgt);
@@ -240,7 +234,7 @@ impl<'a> Graph<'a> {
     ///
     /// This function panics if the length of `tpwgts` is not equal to `ncon`
     /// times `nparts`.
-    pub fn set_tpwgts(mut self, tpwgts: &'a mut [Real]) -> Graph<'a> {
+    pub fn set_tpwgts(mut self, tpwgts: &'a [Real]) -> Graph<'a> {
         let tpwgts_len = Idx::try_from(tpwgts.len()).expect("tpwgts array too large");
         assert_eq!(tpwgts_len, self.ncon * self.nparts);
         self.tpwgts = Some(tpwgts);
@@ -254,7 +248,7 @@ impl<'a> Graph<'a> {
     /// # Panics
     ///
     /// This function panics if the length of `ubvec` is not equal to `ncon`.
-    pub fn set_ubvec(mut self, ubvec: &'a mut [Real]) -> Graph<'a> {
+    pub fn set_ubvec(mut self, ubvec: &'a [Real]) -> Graph<'a> {
         let ubvec_len = Idx::try_from(ubvec.len()).expect("ubvec array too large");
         assert_eq!(ubvec_len, self.ncon);
         self.ubvec = Some(ubvec);
@@ -278,8 +272,8 @@ impl<'a> Graph<'a> {
     /// # use metis::Graph;
     /// use metis::option::Opt;
     ///
-    /// let xadj = &mut [0, 1, 2];
-    /// let adjncy = &mut [1, 0];
+    /// let xadj = &[0, 1, 2];
+    /// let adjncy = &[1, 0];
     /// let mut part = [0, 0];
     ///
     /// // -1 is the default value.
@@ -316,8 +310,8 @@ impl<'a> Graph<'a> {
     ///
     /// ```rust
     /// # use metis::Graph;
-    /// let xadj = &mut [0, 1, 2];
-    /// let adjncy = &mut [1, 0];
+    /// let xadj = &[0, 1, 2];
+    /// let adjncy = &[1, 0];
     /// let mut part = [0, 0];
     ///
     /// Graph::new(1, 2, xadj, adjncy)
@@ -347,7 +341,7 @@ impl<'a> Graph<'a> {
     ///
     /// This function panics if the length of `part` is not the number of
     /// vertices.
-    pub fn part_recursive(mut self, part: &mut [Idx]) -> Result<Idx> {
+    pub fn part_recursive(self, part: &mut [Idx]) -> Result<Idx> {
         let part_len = Idx::try_from(part.len()).expect("part array larger than Idx::MAX");
         assert_eq!(
             part_len,
@@ -355,54 +349,23 @@ impl<'a> Graph<'a> {
             "part.len() must be equal to the number of vertices",
         );
 
-        let nvtxs = &mut (self.xadj.len() as Idx - 1) as *mut Idx;
-        let ncon = &mut self.ncon as *mut Idx;
-        let xadj = self.xadj.as_mut_ptr();
-        let adjncy = self.adjncy.as_mut_ptr();
-        let vwgt = if let Some(vwgt) = self.vwgt {
-            vwgt.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let vsize = if let Some(vsize) = self.vsize {
-            vsize.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let adjwgt = if let Some(adjwgt) = self.adjwgt {
-            adjwgt.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let nparts = &mut self.nparts as *mut Idx;
-        let tpwgts = if let Some(tpwgts) = self.tpwgts {
-            tpwgts.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let ubvec = if let Some(ubvec) = self.ubvec {
-            ubvec.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let options = self.options.as_mut_ptr();
+        let nvtxs = &(self.xadj.len() as Idx - 1);
         let mut edgecut = mem::MaybeUninit::uninit();
-        let part = part.as_mut_ptr();
         unsafe {
             m::METIS_PartGraphRecursive(
                 nvtxs,
-                ncon,
-                xadj,
-                adjncy,
-                vwgt,
-                vsize,
-                adjwgt,
-                nparts,
-                tpwgts,
-                ubvec,
-                options,
+                &self.ncon,
+                self.xadj.as_ptr(),
+                self.adjncy.as_ptr(),
+                self.vwgt.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.vsize.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.adjwgt.map_or_else(ptr::null, <[_]>::as_ptr),
+                &self.nparts,
+                self.tpwgts.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.ubvec.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.options.as_ptr(),
                 edgecut.as_mut_ptr(),
-                part,
+                part.as_mut_ptr(),
             )
             .wrap()?;
             Ok(edgecut.assume_init())
@@ -420,7 +383,7 @@ impl<'a> Graph<'a> {
     ///
     /// This function panics if the length of `part` is not the number of
     /// vertices.
-    pub fn part_kway(mut self, part: &mut [Idx]) -> Result<Idx> {
+    pub fn part_kway(self, part: &mut [Idx]) -> Result<Idx> {
         let part_len = Idx::try_from(part.len()).expect("part array larger than Idx::MAX");
         assert_eq!(
             part_len,
@@ -428,54 +391,23 @@ impl<'a> Graph<'a> {
             "part.len() must be equal to the number of vertices",
         );
 
-        let nvtxs = &mut (self.xadj.len() as Idx - 1) as *mut Idx;
-        let ncon = &mut self.ncon as *mut Idx;
-        let xadj = self.xadj.as_mut_ptr();
-        let adjncy = self.adjncy.as_mut_ptr();
-        let vwgt = if let Some(vwgt) = self.vwgt {
-            vwgt.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let vsize = if let Some(vsize) = self.vsize {
-            vsize.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let adjwgt = if let Some(adjwgt) = self.adjwgt {
-            adjwgt.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let nparts = &mut self.nparts as *mut Idx;
-        let tpwgts = if let Some(tpwgts) = self.tpwgts {
-            tpwgts.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let ubvec = if let Some(ubvec) = self.ubvec {
-            ubvec.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let options = self.options.as_mut_ptr();
+        let nvtxs = &(self.xadj.len() as Idx - 1);
         let mut edgecut = mem::MaybeUninit::uninit();
-        let part = part.as_mut_ptr();
         unsafe {
             m::METIS_PartGraphKway(
                 nvtxs,
-                ncon,
-                xadj,
-                adjncy,
-                vwgt,
-                vsize,
-                adjwgt,
-                nparts,
-                tpwgts,
-                ubvec,
-                options,
+                &self.ncon,
+                self.xadj.as_ptr(),
+                self.adjncy.as_ptr(),
+                self.vwgt.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.vsize.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.adjwgt.map_or_else(ptr::null, <[_]>::as_ptr),
+                &self.nparts,
+                self.tpwgts.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.ubvec.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.options.as_ptr(),
                 edgecut.as_mut_ptr(),
-                part,
+                part.as_mut_ptr(),
             )
             .wrap()?;
             Ok(edgecut.assume_init())
@@ -504,25 +436,25 @@ pub struct Mesh<'a> {
     /// dual graph.
     ncommon: Idx,
 
-    eptr: &'a mut [Idx], // mesh representation
-    eind: &'a mut [Idx], // mesh repr
+    eptr: &'a [Idx], // mesh representation
+    eind: &'a [Idx], // mesh repr
 
     /// The computational weights of the elements.
     ///
     /// Required size: ne
-    vwgt: Option<&'a mut [Idx]>,
+    vwgt: Option<&'a [Idx]>,
 
     /// The communication weights of the elements.
     ///
     /// Required size: ne
-    vsize: Option<&'a mut [Idx]>,
+    vsize: Option<&'a [Idx]>,
 
     /// The target partition weights of the elements.
     ///
     /// If `None` then the mesh is equally divided among the partitions.
     ///
     /// Required size: nparts
-    tpwgts: Option<&'a mut [Real]>,
+    tpwgts: Option<&'a [Real]>,
 
     /// Fine-tuning parameters.
     options: [Idx; NOPTIONS],
@@ -539,13 +471,7 @@ impl<'a> Mesh<'a> {
     /// - `eptr` is empty, or
     /// - the length of `eind` is different than the last element of `eptr`, or
     /// - any of the arrays have a length that cannot be hold by an [`Idx`].
-    ///
-    /// # Mutability
-    ///
-    /// While nothing should be modified by the [`Mesh`] structure, METIS
-    /// doesn't specify any `const` modifier, so everything must be mutable on
-    /// Rust's side.
-    pub fn new(nn: Idx, nparts: Idx, eptr: &'a mut [Idx], eind: &'a mut [Idx]) -> Mesh<'a> {
+    pub fn new(nn: Idx, nparts: Idx, eptr: &'a [Idx], eind: &'a [Idx]) -> Mesh<'a> {
         assert!(0 < nn, "nn must be strictly greater than zero");
         assert!(0 < nparts, "nn must be strictly greater than zero");
         let _ = Idx::try_from(eptr.len()).expect("eptr array larger than Idx::MAX");
@@ -574,7 +500,7 @@ impl<'a> Mesh<'a> {
     ///
     /// This function panics if the length of `vwgt` is not the number of
     /// elements.
-    pub fn set_vwgt(mut self, vwgt: &'a mut [Idx]) -> Mesh<'a> {
+    pub fn set_vwgt(mut self, vwgt: &'a [Idx]) -> Mesh<'a> {
         let vwgt_len = Idx::try_from(vwgt.len()).expect("vwgt array too large");
         assert_eq!(vwgt_len, self.eptr.len() as Idx - 1);
         self.vwgt = Some(vwgt);
@@ -589,7 +515,7 @@ impl<'a> Mesh<'a> {
     ///
     /// This function panics if the length of `vsize` is not the number of
     /// elements.
-    pub fn set_vsize(mut self, vsize: &'a mut [Idx]) -> Mesh<'a> {
+    pub fn set_vsize(mut self, vsize: &'a [Idx]) -> Mesh<'a> {
         let vsize_len = Idx::try_from(vsize.len()).expect("vsize array too large");
         assert_eq!(vsize_len, self.eptr.len() as Idx - 1);
         self.vsize = Some(vsize);
@@ -603,7 +529,7 @@ impl<'a> Mesh<'a> {
     /// # Panics
     ///
     /// This function panics if the length of `tpwgts` is not equal to `nparts`.
-    pub fn set_tpwgts(mut self, tpwgts: &'a mut [Real]) -> Mesh<'a> {
+    pub fn set_tpwgts(mut self, tpwgts: &'a [Real]) -> Mesh<'a> {
         let tpwgts_len = Idx::try_from(tpwgts.len()).expect("tpwgts array too large");
         assert_eq!(tpwgts_len, self.nparts);
         self.tpwgts = Some(tpwgts);
@@ -658,7 +584,7 @@ impl<'a> Mesh<'a> {
     ///
     /// This function panics if the length of `epart` is not the number of
     /// elements, or if `nparts`'s is not the number of nodes.
-    pub fn part_dual(mut self, epart: &mut [Idx], npart: &mut [Idx]) -> Result<Idx> {
+    pub fn part_dual(self, epart: &mut [Idx], npart: &mut [Idx]) -> Result<Idx> {
         let epart_len = Idx::try_from(epart.len()).expect("epart array larger than Idx::MAX");
         assert_eq!(
             epart_len,
@@ -671,39 +597,20 @@ impl<'a> Mesh<'a> {
             "npart.len() must be equal to the number of nodes",
         );
 
-        let ne = &mut (self.eptr.len() as Idx - 1) as *mut Idx;
-        let nn = &mut self.nn as *mut Idx;
-        let vwgt = if let Some(vwgt) = self.vwgt {
-            vwgt.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let vsize = if let Some(vsize) = self.vsize {
-            vsize.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let ncommon = &mut self.ncommon as *mut Idx;
-        let nparts = &mut self.nparts as *mut Idx;
-        let tpwgts = if let Some(tpwgts) = self.tpwgts {
-            tpwgts.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let options = self.options.as_mut_ptr();
+        let ne = &(self.eptr.len() as Idx - 1);
         let mut edgecut = mem::MaybeUninit::uninit();
         unsafe {
             m::METIS_PartMeshDual(
                 ne,
-                nn,
-                self.eptr.as_mut_ptr(),
-                self.eind.as_mut_ptr(),
-                vwgt,
-                vsize,
-                ncommon,
-                nparts,
-                tpwgts,
-                options,
+                &self.nn,
+                self.eptr.as_ptr(),
+                self.eind.as_ptr(),
+                self.vwgt.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.vsize.map_or_else(ptr::null, <[_]>::as_ptr),
+                &self.ncommon,
+                &self.nparts,
+                self.tpwgts.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.options.as_ptr(),
                 edgecut.as_mut_ptr(),
                 epart.as_mut_ptr(),
                 npart.as_mut_ptr(),
@@ -726,7 +633,7 @@ impl<'a> Mesh<'a> {
     ///
     /// This function panics if the length of `epart` is not the number of
     /// elements, or if `nparts`'s is not the number of nodes.
-    pub fn part_nodal(mut self, epart: &mut [Idx], npart: &mut [Idx]) -> Result<Idx> {
+    pub fn part_nodal(self, epart: &mut [Idx], npart: &mut [Idx]) -> Result<Idx> {
         let epart_len = Idx::try_from(epart.len()).expect("epart array larger than Idx::MAX");
         assert_eq!(
             epart_len,
@@ -739,37 +646,19 @@ impl<'a> Mesh<'a> {
             "npart.len() must be equal to the number of nodes",
         );
 
-        let ne = &mut (self.eptr.len() as Idx - 1) as *mut Idx;
-        let nn = &mut self.nn as *mut Idx;
-        let vwgt = if let Some(vwgt) = self.vwgt {
-            vwgt.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let vsize = if let Some(vsize) = self.vsize {
-            vsize.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let nparts = &mut self.nparts as *mut Idx;
-        let tpwgts = if let Some(tpwgts) = self.tpwgts {
-            tpwgts.as_mut_ptr()
-        } else {
-            ptr::null_mut()
-        };
-        let options = self.options.as_mut_ptr();
+        let ne = &(self.eptr.len() as Idx - 1);
         let mut edgecut = mem::MaybeUninit::uninit();
         unsafe {
             m::METIS_PartMeshNodal(
                 ne,
-                nn,
-                self.eptr.as_mut_ptr(),
-                self.eind.as_mut_ptr(),
-                vwgt,
-                vsize,
-                nparts,
-                tpwgts,
-                options,
+                &self.nn,
+                self.eptr.as_ptr(),
+                self.eind.as_ptr(),
+                self.vwgt.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.vsize.map_or_else(ptr::null, <[_]>::as_ptr),
+                &self.nparts,
+                self.tpwgts.map_or_else(ptr::null, <[_]>::as_ptr),
+                self.options.as_ptr(),
                 edgecut.as_mut_ptr(),
                 epart.as_mut_ptr(),
                 npart.as_mut_ptr(),
@@ -824,16 +713,16 @@ impl Drop for Dual {
 /// - `eptr` is empty, or
 /// - `eptr`'s length doesn't fit in [`Idx`].
 pub fn mesh_to_dual(
-    mut nn: Idx,
-    eptr: &mut [Idx],
-    eind: &mut [Idx],
-    mut ncommon: Idx,
-    mut numflag: Idx,
+    nn: Idx,
+    eptr: &[Idx],
+    eind: &[Idx],
+    ncommon: Idx,
+    numflag: Idx,
 ) -> Result<Dual> {
     let eptr_len = Idx::try_from(eptr.len()).expect("eptr array larger than Idx::MAX");
     assert_ne!(eptr_len, 0, "eptr cannot be empty");
 
-    let ne = &mut (eptr_len - 1) as *mut Idx;
+    let ne = &(eptr_len - 1);
     let mut xadj = mem::MaybeUninit::uninit();
     let mut adjncy = mem::MaybeUninit::uninit();
 
@@ -842,11 +731,11 @@ pub fn mesh_to_dual(
     unsafe {
         m::METIS_MeshToDual(
             ne,
-            &mut nn as *mut Idx,
-            eptr.as_mut_ptr(),
-            eind.as_mut_ptr(),
-            &mut ncommon as *mut Idx,
-            &mut numflag as *mut Idx,
+            &nn,
+            eptr.as_ptr(),
+            eind.as_ptr(),
+            &ncommon,
+            &numflag,
             xadj.as_mut_ptr(),
             adjncy.as_mut_ptr(),
         )


### PR DESCRIPTION
redefine METIS functions with const pointers so that there is no need for mut on Rust side.