### PR TITLE
Update MSRV to 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.60.0
+          - 1.61.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -37,7 +37,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.60.0
+          - 1.61.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Prerequisites:
 
 - METIS
 - clang v5.0 or above
-- Rust v1.60.0 or above
+- Rust v1.61.0 or above
 
 Bindings to METIS are made on the fly.  If METIS is installed in a non-standard
 location, please use the following commands:


### PR DESCRIPTION
A transitive dependency of bindgen "memchr" requires 1.61 now.