### PR TITLE
Simplify CI pipeline by directly calling cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,28 +28,15 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
-          components: clippy
+          components: clippy, rustfmt
           toolchain: ${{ matrix.rust }}
       - run: sudo apt-get -y install libmetis-dev libclang-dev
         if: matrix.features == 'use-system'
+      - name: Check Format
+        run: cargo fmt -- --check
       - name: Run Check
         run: cargo check --features ${{ matrix.features }} --no-default-features
       - name: Run Clippy
         run: cargo clippy --features ${{ matrix.features }} --no-default-features
       - name: Run Tests
         run: cargo test --features ${{ matrix.features }} --no-default-features --all
-
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -p metis -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - run: sudo apt-get -y install libmetis-dev libclang-dev
         if: matrix.features == 'use-system'
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-rust-${{ matrix.rust }}-${{ matrix.features }}
-          restore-keys: ${{ runner.os }}-rust-${{ matrix.rust }}-${{ matrix.features }}
       - name: Run Check
         run: cargo check --features ${{ matrix.features }} --no-default-features
       - name: Run Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@$${{ matrix.rust }}
+      - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
+          toolchain: ${{ matrix.rust }}
       - run: sudo apt-get -y install libmetis-dev libclang-dev
         if: matrix.features == 'use-system'
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - 1.67.0
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   test:
     name: Test Suite
     runs-on: ubuntu-22.04
@@ -47,14 +26,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@$${{ matrix.rust }}
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+          components: clippy
       - run: sudo apt-get -y install libmetis-dev libclang-dev
         if: matrix.features == 'use-system'
-      - run: cargo test --features ${{ matrix.features }} --no-default-features --all
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-rust-${{ matrix.rust }}-${{ matrix.features }}
+          restore-keys: ${{ runner.os }}-rust-${{ matrix.rust }}-${{ matrix.features }}
+      - name: Run Check
+        run: cargo check --features ${{ matrix.features }} --no-default-features
+      - name: Run Clippy
+        run: cargo clippy --features ${{ matrix.features }} --no-default-features
+      - name: Run Tests
+        run: cargo test --features ${{ matrix.features }} --no-default-features --all
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-22.04
@@ -62,31 +49,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: -p metis -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -p metis -- -D warnings


### PR DESCRIPTION
Removed separate check and clippy jobs in the GitHub actions CI pipeline, instead calling cargo check, clippy, and test directly in the test job. Also try to cache compilation artifacts.