### PR TITLE
Force optimization for builtin Metis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [metis-sys-0.2.0...0.2.1](https://github.com/LIHPC-Computational-Geometry/metis-rs/compare/metis-0.2.0...metis-0.2.1)
 
+### Added
+
+- `force-optimize-vendor` feature for `metis-sys` to force builtin metis to be compiled as optimized, even for debug or
+  dev profiles [#31](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/31)
+
 ### Fixed
 
 - move `vendor` library in `metis-sys` [#29](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/29)
@@ -14,14 +19,17 @@
 
 ### Added
 
-- Builtin metis with the new `vendored` feature, enabled by default [#16](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/16)
+- Builtin metis with the new `vendored` feature, enabled by
+  default [#16](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/16)
 - Convert from sprs matrices [#10](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/10)
 - Add unchecked constructors [#13](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/13)
 
 ### Changed
 
-- Remove mutability requirement on input from public facing API [#18](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/18)
-- Remove numbering feature, now only Rust (or C) 0-based arrays are supported [#13](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/13)
+- Remove mutability requirement on input from public facing
+  API [#18](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/18)
+- Remove numbering feature, now only Rust (or C) 0-based arrays are
+  supported [#13](https://github.com/LIHPC-Computational-Geometry/metis-rs/pull/13)
 
 ### Documentation
 

--- a/metis-sys/Cargo.toml
+++ b/metis-sys/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["graph", "mesh", "matrix", "partitioning", "ordering"]
 
 
 [features]
-default = ["vendored"]
+default = ["vendored", "force-optimize-vendor"]
 
 # Build and statically link to METIS and GKLib.
 vendored = ["dep:cc"]
@@ -23,6 +23,10 @@ use-system = ["bindgen"]
 # Regenerate bindings in metis-sys/gen/bindings.rs from METIS in the "vendor"
 # directory. Also enables "vendored".
 generate-bindings = ["vendored", "bindgen"]
+
+# Force Metis to be optimized and to not follow the current profile for Rust
+# Therefore, debug or dev build lead to correct performance.
+force-optimize-vendor = ["vendored"]
 
 [build-dependencies]
 bindgen = { version = "0.69", default-features = false, features = ["runtime"], optional = true }

--- a/metis-sys/build.rs
+++ b/metis-sys/build.rs
@@ -126,8 +126,11 @@ fn build_lib() {
         build.define("MACOS", None);
     }
 
-    #[cfg(not(debug_assertions))]
-    build.flag("-DNDEBUG").flag("-DNDEBUG2");
+    #[cfg(any(not(debug_assertions), feature = "force-optimize-vendor"))]
+    build.define("NDEBUG", None).define("NDEBUG2", None);
+
+    #[cfg(feature = "force-optimize-vendor")]
+    build.no_default_flags(true).opt_level(3).debug(false);
 
     // METIS triggers an infinite amount of warnings and showing them to users
     // downstream does not really help.


### PR DESCRIPTION
A new `force-optimize-vendor` feature, on by default, force metis to always be compiled as optimized.

The goal is to not slow down users that use dev or debug profiles.

Fix #19.