### PR TITLE
fix(metis-sys): Do not change vendor compile flags

### DIFF
--- a/metis-sys/build.rs
+++ b/metis-sys/build.rs
@@ -129,9 +129,6 @@ fn build_lib() {
     #[cfg(any(not(debug_assertions), feature = "force-optimize-vendor"))]
     build.define("NDEBUG", None).define("NDEBUG2", None);
 
-    #[cfg(feature = "force-optimize-vendor")]
-    build.no_default_flags(true).opt_level(3).debug(false);
-
     // METIS triggers an infinite amount of warnings and showing them to users
     // downstream does not really help.
     build.warnings(false);


### PR DESCRIPTION
Forcing optimization for vendor library was breaking user passed flags to work correctly (#32).