### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metis-rs
 
-**metis-rs** is a Rust library providing idiomatic bindings to [libmetis][METIS], a library for graph and mesh
+**metis-rs** is a Rust library providing idiomatic bindings to [libmetis][METIS_GH], a library for graph and mesh
 partitioning. It is made to be used with Rust version 1.67.0 or above.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ partitioning. It is made to be used with Rust version 1.67.0 or above.
 
 ## Getting Started
 
-Library released on [crates.io](https://crates.io/crates/metis-rs). To use it, add the following to your `Cargo.toml`:
+Library released on [crates.io](https://crates.io/crates/metis). To use it, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-metis-rs = "0.2"
+metis = "0.2"
 ```
 
 The list of available versions and a change log are available in the [CHANGELOG.md](CHANGELOG.md) file.


### PR DESCRIPTION
* fixed crates.io name being `metis` and not `metis-rs`
* the [libmetis](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) link seems to be dead, redirect to github repo instead